### PR TITLE
Add gitlab as a source for manifests

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,7 +21,8 @@ use ::models::repo::{Repository, RepoPath};
 use ::models::crates::{CrateName, CrateRelease, AnalyzedDependencies};
 
 use ::interactors::crates::QueryCrate;
-use ::interactors::github::{GetPopularRepos, RetrieveFileAtPath};
+use ::interactors::RetrieveFileAtPath;
+use ::interactors::github::{GetPopularRepos};
 
 use self::futures::AnalyzeDependenciesFuture;
 use self::futures::CrawlManifestFuture;

--- a/src/interactors/gitlab.rs
+++ b/src/interactors/gitlab.rs
@@ -1,0 +1,23 @@
+use hyper::Uri;
+use relative_path::RelativePathBuf;
+
+use ::models::repo::RepoPath;
+
+const GITLAB_USER_CONTENT_BASE_URI: &'static str = "https://gitlab.com";
+
+pub fn get_manifest_uri(repo_path: &RepoPath, path: &RelativePathBuf) -> Result<Uri, ::hyper::error::UriError> {
+    let path_str: &str = path.as_ref();
+    // gitlab will return a 308 if the Uri ends with, say, `.../raw/master//Cargo.toml`, so make
+    // sure that last slash isn't doubled
+    let slash_path = if path_str.starts_with("/") {
+        &path_str[1..]
+    } else {
+        path_str
+    };
+    format!("{}/{}/{}/raw/master/{}",
+        GITLAB_USER_CONTENT_BASE_URI,
+        repo_path.qual.as_ref(),
+        repo_path.name.as_ref(),
+        slash_path
+    ).parse::<Uri>()
+}

--- a/src/interactors/mod.rs
+++ b/src/interactors/mod.rs
@@ -1,2 +1,58 @@
+use failure::Error;
+use futures::{Future, IntoFuture, Stream, future};
+use hyper::{Error as HyperError, Method, Request, Response};
+use relative_path::RelativePathBuf;
+use tokio_service::Service;
+
+use ::models::repo::{RepoSite, RepoPath};
+
 pub mod crates;
 pub mod github;
+pub mod gitlab;
+
+
+#[derive(Debug, Clone)]
+pub struct RetrieveFileAtPath<S>(pub S);
+
+impl<S> Service for RetrieveFileAtPath<S>
+    where S: Service<Request=Request, Response=Response, Error=HyperError> + Clone + 'static,
+          S::Future: 'static
+{
+    type Request = (RepoPath, RelativePathBuf);
+    type Response = String;
+    type Error = Error;
+    type Future = Box<Future<Item=Self::Response, Error=Self::Error>>;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        let service = self.0.clone();
+
+        let (repo_path, path) = req;
+        let uri = match &repo_path.site {
+            &RepoSite::Github => {
+                github::get_manifest_uri(&repo_path, &path)
+            },
+            &RepoSite::Gitlab => {
+                gitlab::get_manifest_uri(&repo_path, &path)
+            },
+        };
+        let uri_future = uri.into_future().from_err();
+
+        Box::new(uri_future.and_then(move |uri| {
+            let request = Request::new(Method::Get, uri.clone());
+
+            service.call(request).from_err().and_then(move |response| {
+                let status = response.status();
+                if !status.is_success() {
+                    future::Either::A(future::err(format_err!("Status code {} for URI {}", status, uri)))
+                } else {
+                    let body_future = response.body().concat2().from_err();
+                    let decode_future = body_future
+                        .and_then(|body| String::from_utf8(body.to_vec()).map_err(|err| err.into()));
+                    future::Either::B(decode_future)
+                }
+            })
+        }))
+    }
+}
+
+

--- a/src/models/repo.rs
+++ b/src/models/repo.rs
@@ -27,13 +27,15 @@ impl RepoPath {
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum RepoSite {
-    Github
+    Github,
+    Gitlab,
 }
 
 impl RepoSite {
     pub fn to_base_uri(&self) -> &'static str {
         match self {
-            &RepoSite::Github => "https://github.com"
+            &RepoSite::Github => "https://github.com",
+            &RepoSite::Gitlab => "https://gitlab.com"
         }
     }
 }
@@ -44,6 +46,7 @@ impl FromStr for RepoSite {
     fn from_str(input: &str) -> Result<RepoSite, Error> {
         match input {
             "github" => Ok(RepoSite::Github),
+            "gitlab" => Ok(RepoSite::Gitlab),
             _ => Err(format_err!("unknown repo site identifier"))
         }
     }
@@ -52,7 +55,8 @@ impl FromStr for RepoSite {
 impl AsRef<str> for RepoSite {
     fn as_ref(&self) -> &str {
         match self {
-            &RepoSite::Github => "github"
+            &RepoSite::Github => "github",
+            &RepoSite::Gitlab => "gitlab"
         }
     }
 }

--- a/src/server/views/html/status.rs
+++ b/src/server/views/html/status.rs
@@ -5,7 +5,7 @@ use ordermap::OrderMap;
 
 use ::engine::AnalyzeDependenciesOutcome;
 use ::models::crates::{CrateName, AnalyzedDependency, AnalyzedDependencies};
-use ::models::repo::RepoPath;
+use ::models::repo::{RepoSite, RepoPath};
 use ::server::assets;
 
 fn dependency_tables(crate_name: CrateName, deps: AnalyzedDependencies) -> Markup {
@@ -84,7 +84,15 @@ fn dependency_table(title: &str, deps: OrderMap<CrateName, AnalyzedDependency>) 
     }
 }
 
+fn get_site_icon(repo_site: &RepoSite) -> &'static str {
+    match *repo_site {
+        RepoSite::Github => "fa-github",
+        RepoSite::Gitlab => "fa-gitlab",
+    }
+}
+
 fn render_failure(repo_path: RepoPath) -> Markup {
+    let site_icon = get_site_icon(&repo_path.site);
     html! {
         section class="hero is-light" {
             div class="hero-head" (super::render_navbar())
@@ -92,7 +100,7 @@ fn render_failure(repo_path: RepoPath) -> Markup {
                 div class="container" {
                     h1 class="title is-1" {
                         a href=(format!("{}/{}/{}", repo_path.site.to_base_uri(), repo_path.qual.as_ref(), repo_path.name.as_ref())) {
-                            i class="fa fa-github" ""
+                            i class=(format!("fa {}", site_icon)) ""
                             (format!(" {} / {}", repo_path.qual.as_ref(), repo_path.name.as_ref()))
                         }
                     }
@@ -114,6 +122,7 @@ fn render_failure(repo_path: RepoPath) -> Markup {
 fn render_success(analysis_outcome: AnalyzeDependenciesOutcome, repo_path: RepoPath) -> Markup {
     let self_path = format!("repo/{}/{}/{}", repo_path.site.as_ref(), repo_path.qual.as_ref(), repo_path.name.as_ref());
     let status_base_url = format!("{}/{}", &super::SELF_BASE_URL as &str, self_path);
+    let site_icon = get_site_icon(&repo_path.site);
 
     let (hero_class, status_asset) = if analysis_outcome.any_outdated() {
         ("is-warning", assets::BADGE_OUTDATED_SVG.as_ref())
@@ -130,7 +139,7 @@ fn render_success(analysis_outcome: AnalyzeDependenciesOutcome, repo_path: RepoP
                 div class="container" {
                     h1 class="title is-1" {
                         a href=(format!("{}/{}/{}", repo_path.site.to_base_uri(), repo_path.qual.as_ref(), repo_path.name.as_ref())) {
-                            i class="fa fa-github" ""
+                            i class=(format!("fa {}", site_icon)) ""
                             (format!(" {} / {}", repo_path.qual.as_ref(), repo_path.name.as_ref()))
                         }
                     }


### PR DESCRIPTION
This change adds the ability to use gitlab repositories for status pages only, it does not affect the "Popular repositories" page.

With these commits, you can go to, for example, `https://deps.rs/repo/gitlab/pwoolcoc/pwd` and get the dependency status for a gitlab repository.